### PR TITLE
Stop pretending that the l10n.yml workflow is outside git-l10n's ownership

### DIFF
--- a/util/check-commits.go
+++ b/util/check-commits.go
@@ -995,7 +995,7 @@ func checkCommits(commits ...string) bool {
 			break
 		}
 		for _, change := range changes {
-			if !strings.HasPrefix(change, PoDir+"/") {
+			if !strings.HasPrefix(change, PoDir+"/") && change != ".github/workflows/l10n.yml" {
 				notL10nChanges = append(notL10nChanges, change)
 			} else if change == "po/TEAMS" {
 				l10nChanges = append(l10nChanges, change)


### PR DESCRIPTION
The PR checks would otherwise fail if someone opens a PR to adjust the l10n GitHub workflow, as I did over here:
https://github.com/git-l10n/git-po/pull/749